### PR TITLE
Add get() and count() methods to DBStorage and FileStorage

### DIFF
--- a/models/engine/db_storage.py
+++ b/models/engine/db_storage.py
@@ -74,3 +74,22 @@ class DBStorage:
     def close(self):
         """call remove() method on the private session attribute"""
         self.__session.remove()
+
+    def get(self, cls, id):
+        """ retrieves one object """
+        c = classes[cls]
+        if c is None:
+            return None
+        for v in self.all(c).values():
+            if v.id == id:
+                return v
+        return None
+
+    def count(self, cls=None):
+        """ count number of objects in storage """
+        if cls is None:
+            return len(self.all())
+        else:
+            c = classes[cls]
+            if c is None:
+                return len(self.all())

--- a/models/engine/file_storage.py
+++ b/models/engine/file_storage.py
@@ -68,3 +68,22 @@ class FileStorage:
     def close(self):
         """call reload() method for deserializing the JSON file to objects"""
         self.reload()
+
+    def get(self, cls, id):
+        """ retrieves one object """
+        c = classes[cls]
+        if c is None:
+            return None
+        for v in self.all(c).values():
+            if v.id == id:
+                return v
+        return None
+
+    def count(self, cls=None):
+        """ count number of objects in storage """
+        if cls is None:
+            return len(self.all())
+        else:
+            c = classes[cls]
+            if c is None or cls is None:
+                return len(self.all())

--- a/tests/test_models/test_engine/test_db_storage.py
+++ b/tests/test_models/test_engine/test_db_storage.py
@@ -86,3 +86,22 @@ class TestFileStorage(unittest.TestCase):
     @unittest.skipIf(models.storage_t != 'db', "not testing db storage")
     def test_save(self):
         """Test that save properly saves objects to file.json"""
+
+    @unittest.skipIf(models.storage_t != 'db', "not testing db storage")
+    def test_get(self):
+        """ Test that get method works """
+        s = State(name='TEST')
+        storage.new(s)
+        storage.save()
+        found = storage.get("State", s.id)
+        self.assertTrue(found)
+
+    @unittest.skipIf(models.storage_t != 'db', "not testing db storage")
+    def test_count(self):
+        """ Test that count method works """
+        count = storage.count()
+        s = State(name='TEST2')
+        storage.new(s)
+        storage.save()
+        new_count = storage.count()
+        self.assertNotEqual(count, new_count)

--- a/tests/test_models/test_engine/test_file_storage.py
+++ b/tests/test_models/test_engine/test_file_storage.py
@@ -113,3 +113,22 @@ class TestFileStorage(unittest.TestCase):
         with open("file.json", "r") as f:
             js = f.read()
         self.assertEqual(json.loads(string), json.loads(js))
+
+    @unittest.skipIf(models.storage_t == 'db', "not testing file storage")
+    def test_get(self):
+        """ Test that get method works """
+        s = State(name='TEST')
+        storage.new(s)
+        storage.save()
+        found = storage.get("State", s.id)
+        self.assertTrue(found)
+
+    @unittest.skipIf(models.storage_t == 'db', "not testing file storage")
+    def test_count(self):
+        """ Test that count method works """
+        count = storage.count()
+        s = State(name='TEST2')
+        storage.new(s)
+        storage.save()
+        new_count = storage.count()
+        self.assertNotEqual(count, new_count)


### PR DESCRIPTION
Pull request

Updates DBStorage and FileStorage, adding two new methods. 

A method to retrieve one object:

Prototype: def get(self, cls, id):
cls: class
id: string representing the object ID
Returns the object based on the class and its ID, or None if not found
A method to count the number of objects in storage:

Prototype: def count(self, cls=None):
cls: class (optional)
Returns the number of objects in storage matching the given class. If no class is passed, returns the count of all objects in storage.